### PR TITLE
Add DX edge barcodes if availables + various fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
-default_stages: [commit]
+default_stages: [pre-commit]
 # default_install_hook_types: ["pre-commit"]
 fail_fast: true
 # default_language_version:
@@ -8,7 +8,7 @@ fail_fast: true
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.5.2"
+    rev: "v0.8.6"
     hooks:
       - id: ruff
         name: Code linter (Ruff)
@@ -17,7 +17,7 @@ repos:
         name: Code formatter (Ruff)
 
   - repo: https://github.com/pycqa/bandit
-    rev: "1.7.9"
+    rev: "1.8.0"
     hooks:
       - id: bandit
         name: Code security analysis (bandit)
@@ -27,7 +27,7 @@ repos:
         # stages: [push]  # Uncomment to temporarily accelerate local commits
 
   - repo: https://github.com/djlint/djlint
-    rev: v1.34.1
+    rev: v1.36.4
     hooks:
       - id: djlint
         name: djLint

--- a/app/app.py
+++ b/app/app.py
@@ -4,7 +4,9 @@ from datetime import datetime, timedelta
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
-from starlette.middleware.base import BaseHTTPMiddleware
+from limits import RateLimitItemPerSecond
+from limits.storage import MemoryStorage
+from limits.strategies import SlidingWindowCounterRateLimiter
 
 from app.api.routes import api
 from app.config import settings
@@ -17,40 +19,17 @@ app = FastAPI(title="The Big Film Database")
 # Mount static files
 app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
 
+# Rate limiter
+storage = MemoryStorage()
+limiter = SlidingWindowCounterRateLimiter(storage)
+rate_limit = RateLimitItemPerSecond(settings.RATE_LIMITER_MAX_REQUESTS, settings.RATE_LIMITER_TIME_WINDOW)
 
-class RateLimiterMiddleware(BaseHTTPMiddleware):
-    def __init__(self, app, max_requests: int, window_seconds: int):
-        super().__init__(app)
-        self.max_requests = max_requests
-        self.window_seconds = window_seconds
-        self.request_counts = defaultdict(list)
-
-    async def dispatch(self, request: Request, call_next):
-        client_ip = request.client.host
-        current_time = datetime.now()
-
-        # Cleanup old requests
-        self.request_counts[client_ip] = [
-            request_time
-            for request_time in self.request_counts[client_ip]
-            if current_time - request_time < timedelta(seconds=self.window_seconds)
-        ]
-
-        if len(self.request_counts[client_ip]) >= self.max_requests:
-            return JSONResponse(status_code=429, content={"detail": "Too Many Requests"})
-
-        # Record the new request
-        self.request_counts[client_ip].append(current_time)
-        response = await call_next(request)
-        return response
-
-
-# Add the rate limiter middleware to the app
-app.add_middleware(
-    RateLimiterMiddleware,
-    max_requests=settings.RATE_LIMITER_MAX_REQUESTS,
-    window_seconds=settings.RATE_LIMITER_TIME_WINDOW,
-)
+@app.middleware("http")
+async def rate_limit_middleware(request: Request, call_next):
+    client_ip = request.client.host
+    if not limiter.hit(rate_limit, client_ip):
+        return JSONResponse(status_code=429, content={"detail": "Too Many Requests"})
+    return await call_next(request)
 
 app.include_router(website)
 app.include_router(api)

--- a/app/core/schemas/film.py
+++ b/app/core/schemas/film.py
@@ -4,6 +4,7 @@ from enum import IntEnum
 from typing import Any, Union
 from urllib.parse import urljoin
 
+from app.utils.dx import dx_extract_to_two_part_dx_number
 from pydantic import (
     BaseModel,
     Field,
@@ -105,6 +106,20 @@ class FilmInDB(BaseModel):
             value = None
         return value
 
+    @property
+    def dx_number(self) -> str | None:
+        """
+        Return the DX number in the "XXX-YY" format.
+        
+        XXX (digits) is the DX number part 1 (product code),
+        YY  (digits) is the DX number part 2 (generation code).
+        """
+        if self.dx_extract:
+            return dx_extract_to_two_part_dx_number(self.dx_extract)
+        if self.dx_full:
+            return dx_extract_to_two_part_dx_number(self.dx_full[1:5])
+        return None
+        
     @property
     def dx_extract_full_mismatch(self) -> bool:
         """

--- a/app/utils/barcode_writer.py
+++ b/app/utils/barcode_writer.py
@@ -1,0 +1,24 @@
+import zxingcpp
+
+
+def _remove_background(svg_barcode: str):
+    return svg_barcode.replace('fill="#FFFFFF"', 'fill="#FFFFFF00"', 1)
+
+
+def generate_dx_film_edge_barcode(input: str, size_hint: int = None, with_quiet_zones: bool = True):
+    """Return the DX film edge barcode for the given input.
+
+    The frame number is optional.
+
+    Args:
+        frame_number (str | None, optional): Frame number. Defaults to None.
+
+    Returns:
+        the DX film edge barcode, as SVG
+    """
+    try:
+        barcode = zxingcpp.create_barcode(input, zxingcpp.BarcodeFormat.DXFilmEdge)
+    except ValueError:
+        return None
+    svg = zxingcpp.write_barcode_to_svg(barcode, size_hint, with_quiet_zones=with_quiet_zones)
+    return _remove_background(svg)

--- a/app/utils/dx.py
+++ b/app/utils/dx.py
@@ -38,3 +38,30 @@ def two_parts_dx_number_to_dx_extract(dx_number: str) -> str | None:
         raise ValueError(
             'Invalid DX number. The accepted format is two series of digits separated by a dash. "XXX-XX"'
         ) from e
+
+def dx_extract_to_two_part_dx_number(dx_extract: str) -> str | None:
+    """Convert a 4-digit long DX extract to its DX number equivalent in "XXX-YY" format.        
+        XXX (digits) is the DX number part 1 (product code),
+        YY  (digits) is the DX number part 2 (generation code).
+
+    Args:
+        dx_extract (str): the DX extract (four digits)
+
+    Returns:
+        str | None: The DX number, if a DX extract has been provided
+    """
+    if not dx_extract:
+        return None
+    try:
+        dx_extract = int(dx_extract)
+        if dx_extract < 16:
+            raise ValueError("DX extract value should be at least 16")
+        if dx_extract > 2047:
+            raise ValueError("DX extract value should be at most 2047")
+        dx_part_1 = dx_extract // 16
+        dx_part_2 = dx_extract % 16
+        return f"{dx_part_1}-{dx_part_2}"
+    except Exception as e:
+        raise ValueError("The DX extract should be a number between 16 and 2047") from e
+        
+        

--- a/app/website/routes.py
+++ b/app/website/routes.py
@@ -4,7 +4,7 @@ from collections.abc import Callable
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, Path, Request
-from fastapi.responses import FileResponse, HTMLResponse
+from fastapi.responses import FileResponse, HTMLResponse, RedirectResponse
 from fastapi.routing import APIRoute
 from fastapi.templating import Jinja2Templates
 
@@ -70,14 +70,16 @@ async def search(request: Request, query: Annotated[SearchFilmQuery, Depends(Sea
     if query.dx_extract or query.dx_full:
         dx_extract = query.dx_extract or query.dx_full[1:5]
         film_type = get_film_type(dx_extract)
-
-    films = film.search(
-        dx_extract=query.dx_extract,
-        dx_full=query.dx_full,
-        name=query.name,
-        manufacturer=query.manufacturer,
-        limit=query.limit,
-    )
+    try:
+        films = film.search(
+            dx_extract=query.dx_extract,
+            dx_full=query.dx_full,
+            name=query.name,
+            manufacturer=query.manufacturer,
+            limit=query.limit,
+        )
+    except ValueError:
+        return RedirectResponse(url="/")
     count = len(films)
     too_many_results = False
     if count >= MAX_RESULTS:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,4 +2,4 @@
 
 -r requirements.txt
 
-pre-commit~=3.7.1
+pre-commit~=4.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 
 fastapi~=0.115.6
 Jinja2~=3.1.5
+limits~=4.4.1
 pydantic~=2.10.4
 pydantic-settings~=2.7.1
 uvicorn~=0.34.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 # Application python requirements
 
-fastapi~=0.111.1
-pydantic~=2.8.2
-pydantic-settings~=2.3.4
-uvicorn~=0.30.3
+fastapi~=0.115.6
+Jinja2~=3.1.5
+pydantic~=2.10.4
+pydantic-settings~=2.7.1
+uvicorn~=0.34.0
+zxing-cpp==2.3.0

--- a/templates/film.html
+++ b/templates/film.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 {% block title %}
     {% if film %}
-        {{ film["name"] or "A film with no name" }}
+        {{ film.name or "A film with no name" }}
     {% else %}
         Not found
     {% endif %}
@@ -9,12 +9,12 @@
 {% block content %}
     <footer class="footer">
         {% if film %}
-            {% if film['picture'] %}
-                <img src="{{ film['picture'] }}"
+            {% if film.picture %}
+                <img src="{{ film.picture }}"
                      align="right"
                      width="150"
                      height="100"
-                     alt="{{ film['name'] }}"
+                     alt="{{ film.name }}"
                      loading="lazy">
             {% else %}
                 <img src="{{ url_for('static', path='images/no_picture.webp') }}"
@@ -24,57 +24,61 @@
                      alt="no picture"
                      loading="lazy">
             {% endif %}
-            <strong><a href="{{ film['url_name'] }}">{{ film['name'] }}</a></strong>
+            <strong><a href="{{ film.url_name }}">{{ film.name }}</a></strong>
             <br />
             <br />
-            {% if film['og_film_or_information'] %}
-                <strong>Information / Suspected emulsion:</strong> {{ film['og_film_or_information'] }}
-                {% if film['reliability'] %}
+            {% if film.og_film_or_information %}
+                <strong>Information / Suspected emulsion:</strong> {{ film.og_film_or_information }}
+                {% if film.reliability %}
                     - certitude:
-                    <img src="{{ film['reliability_img'] }}"
+                    <img src="{{ film.reliability_img }}"
                          width="25"
                          height="23"
-                         alt="certitude {{ film['reliability'] }}/4">
+                         alt="certitude {{ film.reliability }}/4">
                 {% endif %}
                 <br />
             {% endif %}
-            {% if film['dx_extract'] %}
-                <strong>DX extract :</strong> <a href="{{ url_for("search") }}?dx_extract={{ film['dx_extract'] }}">{{ film['dx_extract'] }}</a>
+            {% if film.dx_extract %}
+                <strong>DX extract :</strong> <a href="{{ url_for("search") }}?dx_extract={{ film.dx_extract }}">{{ film.dx_extract }}</a>
                 <br />
             {% endif %}
-            {% if film['dx_full'] %}
-                <strong>DX Full code :</strong> <a href="{{ url_for("search") }}?dx_full={{ film['dx_full'] }}">{{ film['dx_full'] }}</a>
+            {% if film.dx_full %}
+                <strong>DX Full code :</strong> <a href="{{ url_for("search") }}?dx_full={{ film.dx_full }}">{{ film.dx_full }}</a>
                 <br />
             {% endif %}
-            {% if film['or_film_or_information'] %}
-                <strong>Original Film or information :</strong> {{ film['or_film_or_information'] }}
+            {% if film.dx_film_edge_barcode_svg() %}
+                <strong>DX Film Edge barcodes :</strong><span title="DX Film Edge Barcode (old format, without frame number)">{{ film.dx_film_edge_barcode_svg() | safe }}</span> or <span title="DX Film Edge Barcode (frame number = 0)">{{ film.dx_film_edge_barcode_svg(0) | safe }}</span>
                 <br />
             {% endif %}
-            {% if film['manufacturers'] %}
+            {% if film.og_film_or_information %}
+                <strong>Original Film or information :</strong> {{ film.og_film_or_information }}
+                <br />
+            {% endif %}
+            {% if film.manufacturers %}
                 <strong>Manufacturer :</strong>
-                {% for manufacturer in film['manufacturers'] %}
+                {% for manufacturer in film.manufacturers %}
                     <a href="{{ url_for("search") }}?manufacturer={{ manufacturer }}">{{ manufacturer }}</a>
                     {% if not loop.last %},{% endif %}
                 {% endfor %}
                 <br />
             {% endif %}
-            {% if film['country'] %}
-                <strong>Origin :</strong> {{ film['country'] }}
+            {% if film.country %}
+                <strong>Origin :</strong> {{ film.country }}
                 <br />
             {% endif %}
-            {% if film['begin_year'] %}
-                <strong>Beginning year :</strong> {{ film['begin_year'] }}
+            {% if film.begin_year %}
+                <strong>Beginning year :</strong> {{ film.begin_year }}
                 <br />
             {% endif %}
-            {% if film['end_year'] %}
-                <strong>End year :</strong> {{ film['end_year'] }}
+            {% if film.end_year %}
+                <strong>End year :</strong> {{ film.end_year }}
                 <br />
             {% endif %}
-            {% if film['distributor'] %}
-                <strong>Distributor :</strong> {{ film['distributor'] }}
+            {% if film.distributor %}
+                <strong>Distributor :</strong> {{ film.distributor }}
                 <br />
             {% endif %}
-            <strong>Availability :</strong> {{ film['availability_label'] | safe }}
+            <strong>Availability :</strong> {{ film.availability_label | safe }}
             <br />
             <br />
         {% else %}

--- a/templates/film.html
+++ b/templates/film.html
@@ -38,7 +38,11 @@
                 {% endif %}
                 <br />
             {% endif %}
-            {% if film.dx_extract %}
+            {% if film['dx_number'] %}
+                <strong>DX number :</strong> <a href="{{ url_for("search") }}?dx_number={{ film['dx_number'] }}">{{ film['dx_number'] }}</a>
+                <br />
+            {% endif %}
+            {% if film['dx_extract'] %}
                 <strong>DX extract :</strong> <a href="{{ url_for("search") }}?dx_extract={{ film.dx_extract }}">{{ film.dx_extract }}</a>
                 <br />
             {% endif %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -11,11 +11,6 @@
         </p>
     </footer>
     <aside class="dxblock">
-        <form action='{{ url_for("search") }}'
-              method="get"
-              name="search-film"
-              id="search-film">
-        </form>
         <h3>
             Search by DX number
             <img src="{{ url_for('static', path='images/dx_code.webp') }}"
@@ -24,9 +19,19 @@
                  height="158"
                  loading="lazy">
         </h3>
+        <form action='{{ url_for("search") }}'
+              method="get"
+              name="search-by-dx-full"
+              id="search-by-dx-full">
+        </form>
+        <form action='{{ url_for("search") }}'
+              method="get"
+              name="search-by-dx-parts"
+              id="search-by-dx-parts">
+        </form>
         <p>
             <br>
-            Please enter the DX full number (6 digits):
+            Search by DX full number (6 digits):
             <br>
             <input minlength="1"
                    maxlength="6"
@@ -34,11 +39,11 @@
                    type="text"
                    name="dx_full"
                    placeholder="DX full barcode (6 digits)"
-                   form="search-film">
-            <button type="submit" form="search-film">Search</button>
+                   form="search-by-dx-full">
+            <button type="submit" form="search-by-dx-full">Search</button>
             <br>
             <br>
-            You can also search by DX number parts 1 and 2:
+            Search by DX number parts 1 and 2:
             <br>
             <input minlength="1"
                    maxlength="10"
@@ -46,8 +51,8 @@
                    type="text"
                    name="dx_number"
                    placeholder="DX number (eg: 115-10)"
-                   form="search-film">
-            <button type="submit" form="search-film">Search</button>
+                   form="search-by-dx-parts">
+            <button type="submit" form="search-by-dx-parts">Search</button>
         </p>
     </aside>
     <article class="filmblock">
@@ -59,26 +64,32 @@
                  height="158"
                  loading="lazy">
         </h3>
+        <form action='{{ url_for("search") }}'
+              method="get"
+              name="search-film"
+              id="search-film">
+        </form>
         <p>
             <br>
-            Please enter film name (eg: "kodak portra 160")
+            Please enter the model name (eg: Lomography APX400).
+            <br>
+            You can also filter by manufacturer (eg: Agfa):
             <br>
             <input maxlength="255"
                    type="text"
                    name="name"
                    placeholder="Model Name"
+                   size="22"
                    form="search-film">
-            <button type="submit" form="search-film">Search</button>
-            <br />
-            <br>
-            You can also search by manufacturer:
-            <br />
             <input maxlength="255"
                    type="text"
                    name="manufacturer"
                    placeholder="Manufacturer"
+                   size="8"
                    form="search-film">
             <button type="submit" form="search-film">Search</button>
+            <br>
+            <br>
         </p>
     </article>
 {% endblock content %}
@@ -86,6 +97,6 @@
     <p>
         {{ total_count }} films in database.
         <br>
-        Random film: <a href="{{ url_for('read_film', url_name=film['url_name']) }}">{{ film['name'] }}</a>
+        Random film: <a href="{{ url_for('read_film', url_name=film.url_name) }}">{{ film.name }}</a>
     </p>
 {% endblock footer %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -21,14 +21,14 @@
                 <p>
                     <strong>IMPORTANT! I am not the original author of the Big Film Database.</strong>
                     <br>
-                    This website is a modified version of <a target="_blank" href="https://industrieplus.net/dxdatabase">The Big Film Database</a>, which is still available (as of July, 2024) and whose <a target="_blank"
+                    This website is a modified version of <a target="_blank" href="https://industrieplus.net/dxdatabase">The Big Film Database</a>, which is still available (as of January, 2025) and whose <a target="_blank"
     href="https://github.com/dxdatabase/Open-source-film-database">the source code has recently been published on GitHub</a>.
                     Likewise, you can find on GitHub the source code of this <a target="_blank"
     href="https://github.com/merinorus/thebigfilmdatabase-website">modified website</a>, as well as the <a href="https://github.com/merinorus/Open-source-film-database"
     target="_blank">modified database</a>.
                     <br />
                     <br />
-                    I'm trying to add features (search by DXN, API) and to improve search performances. You can try the <a href="/docs">API</a>, in alpha stage.
+                    I'm trying to add features (search by DXN, show film edge barcode) and to improve search performances. You can try the <a href="/docs">API</a>, in alpha stage.
                     <br>
                     <a target="_blank"
                        href="https://35mm-compact.com/forum/viewtopic.php?p=1060412#p1060412">The future of this website is under discussion on the 35mm-compact.com forum (in French)</a>.

--- a/templates/search.html
+++ b/templates/search.html
@@ -13,12 +13,12 @@
     </div>
     {% for film in films %}
         <footer class="footer">
-            {% if film['picture'] %}
-                <img src="{{ film['picture'] }}"
+            {% if film.picture %}
+                <img src="{{ film.picture }}"
                      align="right"
                      width="150"
                      height="100"
-                     alt="{{ film['name'] }}"
+                     alt="{{ film.name }}"
                      loading="lazy">
             {% else %}
                 <img src="{{ url_for('static', path='images/no_picture.webp') }}"
@@ -28,57 +28,61 @@
                      alt="no picture"
                      loading="lazy">
             {% endif %}
-            <strong><a href="{{ url_for('read_film', url_name=film['url_name']) }}">{{ film['name'] }}</a></strong>
+            <strong><a href="{{ url_for('read_film', url_name=film.url_name) }}">{{ film.name }}</a></strong>
             <br />
             <br />
-            {% if film['og_film_or_information'] %}
-                <strong>Information / Suspected emulsion:</strong> {{ film['og_film_or_information'] }}
-                {% if film['reliability'] %}
+            {% if film.og_film_or_information %}
+                <strong>Information / Suspected emulsion:</strong> {{ film.og_film_or_information }}
+                {% if film.reliability %}
                     - certitude:
-                    <img src="{{ film['reliability_img'] }}"
+                    <img src="{{ film.reliability_img }}"
                          width="25"
                          height="23"
-                         alt="certitude {{ film['reliability'] }}/4">
+                         alt="certitude {{ film.reliability }}/4">
                 {% endif %}
                 <br />
             {% endif %}
-            {% if film['dx_extract'] %}
-                <strong>DX extract :</strong> <a href="{{ url_for("search") }}?dx_extract={{ film['dx_extract'] }}">{{ film['dx_extract'] }}</a>
+            {% if film.dx_extract %}
+                <strong>DX extract :</strong> <a href="{{ url_for("search") }}?dx_extract={{ film.dx_extract }}">{{ film.dx_extract }}</a>
                 <br />
             {% endif %}
-            {% if film['dx_full'] %}
-                <strong>DX Full code :</strong> <a href="{{ url_for("search") }}?dx_full={{ film['dx_full'] }}">{{ film['dx_full'] }}</a>
+            {% if film.dx_full %}
+                <strong>DX Full code :</strong> <a href="{{ url_for("search") }}?dx_full={{ film.dx_full }}">{{ film.dx_full }}</a>
                 <br />
             {% endif %}
-            {% if film['or_film_or_information'] %}
-                <strong>Original Film or information :</strong> {{ film['or_film_or_information'] }}
+            {% if film.dx_film_edge_barcode_svg() %}
+                <strong>DX Film Edge barcodes :</strong><span title="DX Film Edge Barcode (old format, without frame number)">{{ film.dx_film_edge_barcode_svg() | safe }}</span> or <span title="DX Film Edge Barcode (frame number = 0)">{{ film.dx_film_edge_barcode_svg(0) | safe }}</span>
                 <br />
             {% endif %}
-            {% if film['manufacturers'] %}
+            {% if film.og_film_or_information %}
+                <strong>Original Film or information :</strong> {{ film.og_film_or_information }}
+                <br />
+            {% endif %}
+            {% if film.manufacturers %}
                 <strong>Manufacturer :</strong>
-                {% for manufacturer in film['manufacturers'] %}
+                {% for manufacturer in film.manufacturers %}
                     <a href="{{ url_for("search") }}?manufacturer={{ manufacturer }}">{{ manufacturer }}</a>
                     {% if not loop.last %},{% endif %}
                 {% endfor %}
                 <br />
             {% endif %}
-            {% if film['country'] %}
-                <strong>Origin :</strong> {{ film['country'] }}
+            {% if film.country %}
+                <strong>Origin :</strong> {{ film.country }}
                 <br />
             {% endif %}
-            {% if film['begin_year'] %}
-                <strong>Beginning year :</strong> {{ film['begin_year'] }}
+            {% if film.begin_year %}
+                <strong>Beginning year :</strong> {{ film.begin_year }}
                 <br />
             {% endif %}
-            {% if film['end_year'] %}
-                <strong>End year :</strong> {{ film['end_year'] }}
+            {% if film.end_year %}
+                <strong>End year :</strong> {{ film.end_year }}
                 <br />
             {% endif %}
-            {% if film['distributor'] %}
-                <strong>Distributor :</strong> {{ film['distributor'] }}
+            {% if film.distributor %}
+                <strong>Distributor :</strong> {{ film.distributor }}
                 <br />
             {% endif %}
-            <strong>Availability :</strong> {{ film['availability_label'] | safe }}
+            <strong>Availability :</strong> {{ film.availability_label | safe }}
             <br />
             <br />
         </footer>

--- a/templates/search.html
+++ b/templates/search.html
@@ -42,8 +42,12 @@
                 {% endif %}
                 <br />
             {% endif %}
-            {% if film.dx_extract %}
-                <strong>DX extract :</strong> <a href="{{ url_for("search") }}?dx_extract={{ film.dx_extract }}">{{ film.dx_extract }}</a>
+            {% if film['dx_number'] %}
+                <strong>DX number:</strong> <a href="{{ url_for("search") }}?dx_number={{ film['dx_number'] }}">{{ film['dx_number'] }}</a>
+                <br />
+            {% endif %}
+            {% if film['dx_extract'] %}
+            <strong>DX extract :</strong> <a href="{{ url_for("search") }}?dx_extract={{ film.dx_extract }}">{{ film.dx_extract }}</a>
                 <br />
             {% endif %}
             {% if film.dx_full %}


### PR DESCRIPTION
- Generate the DX Film Edge barcode in the search results, if available
- Search form is now a bit more user friendly
- Redirect to the index page if no search parameter is given, instead of crashing
- Fix "original film" information missing
- Add "DX number" in search results and film details
- RAM-friendly rate limiter (https://github.com/alisaifee/limits/pull/248)
- Code cleaning