### PR TITLE
Fix search by name

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ fail_fast: true
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.8.6"
+    rev: "v0.11.3"
     hooks:
       - id: ruff
         name: Code linter (Ruff)
@@ -17,7 +17,7 @@ repos:
         name: Code formatter (Ruff)
 
   - repo: https://github.com/pycqa/bandit
-    rev: "1.8.0"
+    rev: "1.8.3"
     hooks:
       - id: bandit
         name: Code security analysis (bandit)

--- a/app/app.py
+++ b/app/app.py
@@ -1,6 +1,3 @@
-from collections import defaultdict
-from datetime import datetime, timedelta
-
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
@@ -24,12 +21,14 @@ storage = MemoryStorage()
 limiter = SlidingWindowCounterRateLimiter(storage)
 rate_limit = RateLimitItemPerSecond(settings.RATE_LIMITER_MAX_REQUESTS, settings.RATE_LIMITER_TIME_WINDOW)
 
+
 @app.middleware("http")
 async def rate_limit_middleware(request: Request, call_next):
     client_ip = request.client.host
     if not limiter.hit(rate_limit, client_ip):
         return JSONResponse(status_code=429, content={"detail": "Too Many Requests"})
     return await call_next(request)
+
 
 app.include_router(website)
 app.include_router(api)

--- a/app/core/schemas/film.py
+++ b/app/core/schemas/film.py
@@ -4,7 +4,6 @@ from enum import IntEnum
 from typing import Any, Union
 from urllib.parse import urljoin
 
-from app.utils.dx import dx_extract_to_two_part_dx_number
 from pydantic import (
     BaseModel,
     Field,
@@ -17,6 +16,7 @@ from pydantic_core import CoreSchema, core_schema
 
 from app.config import settings
 from app.utils.barcode_writer import generate_dx_film_edge_barcode
+from app.utils.dx import dx_extract_to_two_part_dx_number
 
 image_cdn_base_url = settings.IMAGE_CDN_BASE_URLS[0]
 
@@ -110,7 +110,7 @@ class FilmInDB(BaseModel):
     def dx_number(self) -> str | None:
         """
         Return the DX number in the "XXX-YY" format.
-        
+
         XXX (digits) is the DX number part 1 (product code),
         YY  (digits) is the DX number part 2 (generation code).
         """
@@ -119,7 +119,7 @@ class FilmInDB(BaseModel):
         if self.dx_full:
             return dx_extract_to_two_part_dx_number(self.dx_full[1:5])
         return None
-        
+
     @property
     def dx_extract_full_mismatch(self) -> bool:
         """

--- a/app/install.py
+++ b/app/install.py
@@ -34,22 +34,6 @@ def update_db():
     db_column_names = deepcopy(df_column_names)
     db_column_names.append("url_name")
 
-    # db_column_names = [
-    #     "dx_extract",
-    #     "dx_full",
-    #     "name",
-    #     "url_name",
-    #     "og_film_or_information",
-    #     "manufacturer",
-    #     "reliability",
-    #     "country",
-    #     "begin_year",
-    #     "end_year",
-    #     "distributor",
-    #     "availability",
-    #     "picture",
-    # ]
-
     print(f"db_column_names: {db_column_names}")
     # Load the CSV file
     df: pd.DataFrame = pd.read_csv(
@@ -77,12 +61,6 @@ def update_db():
     for column_name in ["reliability"]:
         df[column_name] = df[column_name].astype(float)
         df[column_name] = df[column_name].fillna("")
-        # df[column_name] = df[column_name].astype(str)
-
-    #         df[col] = df[col].fillna(-1)
-    # df[col] = df[col].astype(int)
-    # df[col] = df[col].astype(str)
-    # df[col] = df[col].replace('-1', np.nan)
 
     for column_name in ["dx_extract", "dx_full"]:
         df[column_name] = df[column_name].fillna(0)
@@ -90,11 +68,6 @@ def update_db():
         df[column_name] = df[column_name].fillna("").astype(int)
         df[column_name] = df[column_name].replace(0, "")
         df[column_name] = df[column_name].astype(str)
-        # df[column_name] = df[column_name].fillna('').astype(int)
-        # df[column_name] = df[column_name].fill
-
-    # TODO reliability in float/int ?
-    # df['reliability'] = df['reliability'].fillna('').astype(int)
 
     # Add leading zeros to DX codes
     df["dx_full"] = df["dx_full"].str.zfill(6)
@@ -104,24 +77,15 @@ def update_db():
     df["dx_extract"] = df["dx_extract"].apply(lambda x: None if x == "0000" else x)
 
     # Strip leading and trailing spaces from string columns
-    df = df.applymap(lambda x: x.strip() if isinstance(x, str) else x)
+    df = df.map(lambda x: x.strip() if isinstance(x, str) else x)
 
     # Encode film name
     df["url_name"] = df["name"].apply(generate_unique_url)
 
     # Save the dataframe to a SQLite database
     pathlib.Path(settings.DB_SQLITE_FILEPATH).parent.mkdir(parents=True, exist_ok=True)
-    # assert False, pathlib.Path(settings.DB_SQLITE_FILEPATH).parent
-    # assert False, settings.DB_SQLITE_FILEPATH
+
     db_file_connection = sqlite3.connect(settings.DB_SQLITE_FILEPATH)
-    # df.to_sql('films', db_file_connection, if_exists='replace', index=False)
-
-    # # Convertir les NaN en chaînes vides et s'assurer que les colonnes sont des chaînes
-    # df = df.fillna("").astype(str)
-
-    # Convertir les NaN en NULL values en SQL et s'assurer que les colonnes sont des chaînes
-    # df = df.replace("", None)
-    # df = df.applymap(lambda x: None if isinstance(x, str) and x == "" else x)
 
     print(df[0:10])
     print(df[2700:2710])
@@ -133,15 +97,9 @@ def update_db():
     create_table_query = f"CREATE VIRTUAL TABLE IF NOT EXISTS {DB_TABLE_NAME} USING FTS5({', '.join(db_column_names)});"
     print(create_table_query)
     cursor.execute(create_table_query)
-    # cursor.execute('create virtual table films using fts5(title, genre, rating, tokenize="porter unicode61");')
 
     # Charger le DataFrame dans SQLite
     df.to_sql(name=DB_TABLE_NAME, con=db_file_connection, if_exists="append", index=False)
-
-    # # Replace empty strings by null values
-    # for column in db_column_names:
-    #     db_query = f"UPDATE films SET {column} = CASE WHEN {column} = '' THEN NULL ELSE {column} END;"
-    #     cursor.execute(db_query)
 
     db_file_connection.commit()
 
@@ -152,8 +110,7 @@ def update_db():
     print(len(films))
     for film in films[47:49]:
         print(film)
-    # ta = TypeAdapter(list[Film])
-    # film_list = ta.validate_python(films)
+
     ta = TypeAdapter(list[HTMLFilmInDB])
     film_list = ta.validate_python(films)
     for film in film_list[47:49]:

--- a/app/install.py
+++ b/app/install.py
@@ -130,7 +130,7 @@ def update_db():
     # Prepare database table with fulltext index
     cursor = db_file_connection.cursor()
     cursor.execute(f"DROP TABLE IF EXISTS {DB_TABLE_NAME}")
-    create_table_query = f'CREATE VIRTUAL TABLE IF NOT EXISTS {DB_TABLE_NAME} USING FTS5({", ".join(db_column_names)});'
+    create_table_query = f"CREATE VIRTUAL TABLE IF NOT EXISTS {DB_TABLE_NAME} USING FTS5({', '.join(db_column_names)});"
     print(create_table_query)
     cursor.execute(create_table_query)
     # cursor.execute('create virtual table films using fts5(title, genre, rating, tokenize="porter unicode61");')

--- a/app/utils/dx.py
+++ b/app/utils/dx.py
@@ -48,7 +48,7 @@ def dx_extract_to_two_part_dx_number(dx_extract: str) -> str | None:
         dx_extract (str): the DX extract (four digits)
 
     Returns:
-        str | None: The DX number, if a DX extract has been provided
+        str | None: The DX number, if a valid DX extract has been provided, else None
     """
     if not dx_extract:
         return None
@@ -61,7 +61,6 @@ def dx_extract_to_two_part_dx_number(dx_extract: str) -> str | None:
         dx_part_1 = dx_extract // 16
         dx_part_2 = dx_extract % 16
         return f"{dx_part_1}-{dx_part_2}"
-    except Exception as e:
-        raise ValueError("The DX extract should be a number between 16 and 2047") from e
-        
-        
+    except Exception:
+        # Silently fail
+        return None

--- a/app/utils/dx.py
+++ b/app/utils/dx.py
@@ -39,8 +39,9 @@ def two_parts_dx_number_to_dx_extract(dx_number: str) -> str | None:
             'Invalid DX number. The accepted format is two series of digits separated by a dash. "XXX-XX"'
         ) from e
 
+
 def dx_extract_to_two_part_dx_number(dx_extract: str) -> str | None:
-    """Convert a 4-digit long DX extract to its DX number equivalent in "XXX-YY" format.        
+    """Convert a 4-digit long DX extract to its DX number equivalent in "XXX-YY" format.
         XXX (digits) is the DX number part 1 (product code),
         YY  (digits) is the DX number part 2 (generation code).
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,4 +2,4 @@
 
 -r requirements.txt
 
-pre-commit~=4.0.1
+pre-commit~=4.2.0

--- a/requirements-install.txt
+++ b/requirements-install.txt
@@ -1,4 +1,4 @@
 -r requirements.txt
 
-numpy~=2.0.1
-pandas~=2.2.2
+numpy~=2.2.4
+pandas~=2.2.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 # Application python requirements
 
-fastapi~=0.115.6
-Jinja2~=3.1.5
+fastapi~=0.115.12
+Jinja2~=3.1.6
 limits~=4.4.1
-pydantic~=2.10.4
-pydantic-settings~=2.7.1
+pydantic~=2.11.2
+pydantic-settings~=2.8.1
 uvicorn~=0.34.0
 zxing-cpp==2.3.0

--- a/templates/search.html
+++ b/templates/search.html
@@ -47,7 +47,7 @@
                 <br />
             {% endif %}
             {% if film['dx_extract'] %}
-            <strong>DX extract :</strong> <a href="{{ url_for("search") }}?dx_extract={{ film.dx_extract }}">{{ film.dx_extract }}</a>
+                <strong>DX extract :</strong> <a href="{{ url_for("search") }}?dx_extract={{ film.dx_extract }}">{{ film.dx_extract }}</a>
                 <br />
             {% endif %}
             {% if film.dx_full %}


### PR DESCRIPTION
- Silently fail when parsing incorrect DX extract to DX number, instead of raising an error. Otherwise, this led to a crash when a film with an incorrect DX extract / DX full code was serialized.
- Update dependencies.
- Clean deprecated and commented code.